### PR TITLE
ipmikvm: add -F option for reading password from file

### DIFF
--- a/ipmikvm
+++ b/ipmikvm
@@ -75,11 +75,11 @@ PROXY_PORT_MAPPING='80:5980 443:5943 623:5923 5900:5959'
 PROXY_IP=  # dynamic?
 
 # Use getopt(1) to reorder arguments
-eval set --"$(getopt -- 'hu:P:L:' "$@")"
+eval set --"$(getopt -- 'hu:P:F:L:' "$@")"
 
 usage() {
     test ${1:-1} -ne 0 && exec >&2  # non-zero? write to stderr
-    echo "Usage: $0 [-u ADMIN] [-P ADMIN] IP.ADD.RE.SS"
+    echo "Usage: $0 [-u ADMIN] [-P ADMIN] [-F passwordfile] IP.ADD.RE.SS"
     echo
     echo "If you're setting up an ssh tunnel, you can specify a local IP"
     echo "like 127.75.86.77 and do this:"
@@ -109,17 +109,32 @@ curl() {
     command curl "$url" "$@"
 }
 
-while getopts 'hu:P:L:' OPTION; do
+PASSFILE=
+while getopts 'hu:P:F:L:' OPTION; do
     case "$OPTION" in
     h) usage 0;;
     u) USER=$OPTARG;;
     P) PASS=$OPTARG;;
+    F) PASSFILE=$OPTARG;;
     L) PROXY_IP=$OPTARG;;
     #v) PROXY_PORT_MAPPING=$OPTARG;;
     ?) usage 1;;
     esac
 done
 shift $((OPTIND - 1))
+
+if test -n "$PASS" && test -n "$PASSFILE"; then
+  echo "Please use either -P or -F -- not both"
+  exit 1
+fi
+
+if test -n "$PASSFILE"; then
+  PASS=$(head -n 1 "$PASSFILE")
+  if test -z "$PASS"; then
+    echo "Got empty password from file: $PASSFILE"
+    exit 1
+  fi
+fi
 
 test $# -ne 1 && usage
 IP=${1:-}; shift


### PR DESCRIPTION
This lets us avoid both keeping password in plaintext (the dict file),
and exposing it on the command-line, like:

ipmikvm -u admin -F <(pass show servers/foo) 10.0.0.1
