### PR TITLE
cert-expiry-finder: add grafana alloy certificates to expiry check

### DIFF
--- a/cert-expiry-finder
+++ b/cert-expiry-finder
@@ -37,6 +37,7 @@ enum_all_certs() {
         enum_dovecot_certs
         enum_gitlab_certs
         enum_grafana_agent_certs
+        enum_grafana_alloy_certs
         enum_haproxy_certs
         enum_kuberstuff_certs
         enum_mysql_wsrep_certs
@@ -78,6 +79,12 @@ enum_grafana_agent_certs() {
     sed -e "
         /^$s*cert_file:/!d;s/^[^:]*:$s*//;s/$s*//" \
         /etc/grafana-agent.yaml 2>/dev/null || true
+}
+
+enum_grafana_alloy_certs() {
+    sed -e "
+        /^$s*cert_file$s*=/!d;s/^[^=]*=$s*//;s/\"//g" \
+        /etc/alloy/config.alloy 2>/dev/null || true
 }
 
 enum_haproxy_certs() {


### PR DESCRIPTION
We use [Grafana Alloy](https://grafana.com/docs/alloy/latest/) as our otel collector. This agent can use client certificates to connect with the remote instance, e.g. Loki. This allows us to keep an eye on the expiry date of those client certificates.