### PR TITLE
Implement XDG base dir spec

### DIFF
--- a/ikvmocr
+++ b/ikvmocr
@@ -41,6 +41,8 @@ from tempfile import NamedTemporaryFile
 
 from PIL import Image
 
+DATA_DIR = f'{os.environ.get("XDG_DATA_HOME", "~/.local/share")}/ikvmocr'
+
 
 class Extent:
     def __init__(self, top, right, bottom, left):
@@ -526,7 +528,7 @@ def read_screenshot_and_dump(screenshot_filename, glyphs):
 def main(screenshot_filenames, glyph_db_filename):
     glyph_db_filenames = [
         glyph_db_filename,
-        os.path.expanduser('~/.local/share/ikvmocr/ikvmocr.js'),
+        os.path.expanduser(f'{DATA_DIR}/ikvmocr.js'),
     ]
     glyphs = ConsoleGlyphs()
     for glyph_db_filename in glyph_db_filenames:
@@ -563,7 +565,7 @@ def main(screenshot_filenames, glyph_db_filename):
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        print('''\
+        print(f'''\
 usage: ikvmocr SCREENSHOT_FILE...
 
 ikvmocr looks for a SuperMicro iKVM console window in the screenshot and does
@@ -573,7 +575,7 @@ If you use GNOME, take a window-only screenshot of your iKVM window using
 Alt-PrintScreen and feed the saved PNG image to ikvmocr.
 
 The glyph configuration file is taken from the same directory as the binary,
-if it exists. Otherwise it uses ~/.local/share/ikvmocr/ikvmocr.js.
+if it exists. Otherwise it uses {DATA_DIR}/ikvmocr.js.
 
 See also:
 - ipmikvm(1) to simply connecting to SuperMicro IPMI KVM from the console

--- a/ipmikvm
+++ b/ipmikvm
@@ -64,7 +64,7 @@ for binary in java unzip curl awk base64 grep sed flock; do
 done
 
 IP=
-DICT="$HOME/.config/ipmikvm/dict"
+DICT="${XDG_CONFIG_HOME:-${HOME?}/.config}/ipmikvm/dict"
 USER=
 PASS=
 USERS='ADMIN '
@@ -90,7 +90,7 @@ usage() {
     echo "  $0 -L 127.0.0.2 IP.ADD.RE.SS"
     echo
     echo "Usernames, passwords and machine aliases may be specified in"
-    echo "~/.config/ipmikvm/dict (or the file set with -c)"
+    echo "$DICT (or the file set with -c)"
     echo "- as ALIAS ADDRESS USER PASS - one per line. When ALIAS and"
     echo "ADDRESS are *, the USER and PASS will be tried consecutively"
     echo "for (otherwise) unmatched aliases/addresses."

--- a/ipmiscrape
+++ b/ipmiscrape
@@ -18,6 +18,7 @@ POOL_SIZE = 30
 PROCESS_TIMEOUT = 1.5
 IPMI_USER_PASS_BY_ALIAS = {'*': ('ADMIN', 'ADMIN')}  # ~/.config/ipmikvm/dict
 IPMI_USER_PASS_BY_IP = {'*': ('ADMIN', 'ADMIN')}     # ~/.config/ipmikvm/dict
+CONF_DIR = f'{os.environ.get("XDG_CONFIG_HOME", "~/.config")}/ipmikvm'
 
 
 Machine = namedtuple('Machine', 'hostname ipmi_ip')
@@ -244,7 +245,7 @@ def read_config_ipmikvm_dict():
     # * * ADMIN SIMPLEPASS
     # * * ADMIN OTHERPASS
     # machinex 1.2.3.4 ROOT ROOTPASS
-    with open(os.path.expanduser('~/.config/ipmikvm/dict')) as fp:
+    with open(os.path.expanduser(f'{CONF_DIR}/dict')) as fp:
         for line in fp:
             line = line.strip()
             if line and not line.startswith('#'):

--- a/nbdig
+++ b/nbdig
@@ -34,7 +34,7 @@ from configparser import ConfigParser, MissingSectionHeaderError
 from fnmatch import translate as glob_to_re
 from ipaddress import IPv4Address, IPv4Network
 from json import dumps
-from os import path
+from os import environ, path
 from re import IGNORECASE, compile as re_compile, split as re_split
 from sys import stderr
 from warnings import warn
@@ -43,7 +43,7 @@ import requests
 import warnings
 
 
-INI_DEFAULT = '~/.config/nbdig.ini'
+CONF_FILE = f'{environ.get("XDG_CONFIG_HOME", "~/.config")}/nbdig.ini'
 
 
 def net2ip(s):
@@ -58,7 +58,7 @@ class StartupError(ValueError):
 class Config(namedtuple('Config', 'api_url api_token')):
     @classmethod
     def from_defaults(cls):
-        return cls.from_ini(path.expanduser(INI_DEFAULT))
+        return cls.from_ini(path.expanduser(CONF_FILE))
 
     @classmethod
     def from_ini(cls, filename):
@@ -643,7 +643,7 @@ def main():
     parser = ArgumentParser(prog='nbdig', description='(zab)dig for netbox')
     parser.add_argument(
         '-c', '--config', metavar='INIFILE',
-        help=f'configuration INI location (default: {INI_DEFAULT})')
+        help=f'configuration INI location (default: {CONF_FILE})')
     parser.add_argument(
         '-i', '--iface', metavar='IFACE', help='interface lookup')
     parser.add_argument(

--- a/wvpn
+++ b/wvpn
@@ -232,7 +232,7 @@ list() {
 
 # Use local config to define groups, like:
 # bestvpn='vpn-system1 vpn-system2'
-local_config=$HOME/.config/wvpn
+local_config="${XDG_CONFIG_HOME:-${HOME?}/.config}/wvpn"
 test -f "$local_config" && . "$local_config"
 
 if test $# -eq 0; then

--- a/zabdig
+++ b/zabdig
@@ -68,6 +68,10 @@ from datetime import datetime, timezone
 from fnmatch import fnmatch
 from warnings import warn
 
+CONF_FILE = f'{os.environ.get('XDG_CONFIG_HOME', '~/.config')}/.zabbixrc'
+if not os.path.exists(os.path.expanduser(CONF_FILE)):
+    CONF_FILE = '~/.zabbixrc'
+
 
 class ZConfigError(ValueError):
     pass
@@ -689,7 +693,7 @@ class ZInterface(object):
 class LocalConfig(object):
     def __init__(self):
         self.config = configparser.ConfigParser()
-        self.config.read(os.path.expanduser('~/.zabbixrc'))  # silent failure
+        self.config.read(os.path.expanduser(CONF_FILE))  # silent failure
         if self.config.sections():
             self.section = self.config.sections()[0]
         else:
@@ -773,7 +777,7 @@ if __name__ == '__main__':
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '-g', '--section', dest='section', help=(
-                'Use SECTION from ~/.zabbixrc for defaults'))
+                f'Use SECTION from {CONF_FILE} for defaults'))
         parser.add_argument(
             '-A', '--api', dest='api', help=(
                 'Zabbix json_rpc API URL, for example: '


### PR DESCRIPTION
Update scripts to follow the XDG base dir spec to determine where we store or load data from, like config or cache files.

Fixes #52